### PR TITLE
Update Dockerfile with latest and greatest

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,44 @@
+name: release
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Clone Pipeline Action
+        uses: actions/checkout@v2
+        with:
+          repository: ennismore/pipeline-template
+          ref: v0.0.1
+          token: ${{ secrets.EM_BOT_TOKEN }}
+          path: .ennismore/pipeline-template
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ECR_AK }}
+          aws-secret-access-key: ${{ secrets.ECR_SK }}
+          aws-region: eu-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Docker Build and Push
+        id: docker_build_and_push
+        uses: docker/build-push-action@v2
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ github.event.repository.name }}
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apt-get update \
         maven \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://dl.google.com/go/go1.13.6.linux-amd64.tar.gz \
+RUN wget https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz \
     && mkdir /go \
-    && tar -C / -xzf go1.13.6.linux-amd64.tar.gz
+    && tar -C / -xzf go1.18.2.linux-amd64.tar.gz
 
 ENV GOBIN="/go/bin"
 ENV PATH="${PATH}:${GOBIN}"
@@ -22,17 +22,15 @@ RUN download_url=$(curl -s https://api.github.com/repos/go-swagger/go-swagger/re
 RUN git clone https://github.com/googleapis/googleapis.git \
     && git clone https://github.com/grpc-ecosystem/grpc-gateway.git
 
-RUN curl -OL https://github.com/google/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-x86_64.zip \
-    && unzip protoc-3.10.1-linux-x86_64.zip -d protoc3 \
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-linux-x86_64.zip \
+    && unzip protoc-3.20.1-linux-x86_64.zip -d protoc3 \
     && mv protoc3/bin/* /usr/local/bin/ \
     && mv protoc3/include/* /usr/local/include/ \
     && chown root /usr/local/bin/protoc \
     && chown -R root /usr/local/include/google
 
-RUN go get -u github.com/golang/protobuf/protoc-gen-go \
-    && go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
-    && go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
-    && go get -u github.com/markbates/pkger/cmd/pkger 
-
-ADD https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-amd64 /usr/bin/dep
-RUN chmod +x /usr/bin/dep
+RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest
+RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+RUN go install github.com/markbates/pkger/cmd/pkger@latest


### PR DESCRIPTION
Bump:
- Go: 1.18.2
- Protoc: 3.20.1
- All Go deps

Adds CI to push to ECR

Note: this is just short-term for keeping em-domain in-line with new protobuf work. Can be dropped when fully migrated.